### PR TITLE
Update selector for clicking tabs

### DIFF
--- a/pages/apply/applyPage.ts
+++ b/pages/apply/applyPage.ts
@@ -58,6 +58,6 @@ export class ApplyPage extends BasePage {
   }
 
   async clickTab(title: string) {
-    await this.page.getByRole('tab', { name: title }).click()
+    await this.page.getByRole('link', { name: title }).click()
   }
 }


### PR DESCRIPTION
The `role=tab` was removed recently as the automated Accessiblity tests didn’t like it. We can now use a `link` role.