### PR TITLE
Fix - Mark an arrival

### DIFF
--- a/pages/manage/arrivalFormPage.ts
+++ b/pages/manage/arrivalFormPage.ts
@@ -41,7 +41,7 @@ export class ArrivalFormPage extends BasePage {
   }
 
   async selectKeyWorker() {
-    await this.page.getByRole('combobox', { name: 'Key Worker' }).selectOption({ label: 'Al Rice' })
+    await this.page.getByRole('combobox', { name: 'Key Worker' }).selectOption({ index: 1 })
   }
 
   async completeForm() {


### PR DESCRIPTION
The names of the Key Workers are liable to change so it is more reliable to just grab the first one