### PR TITLE
Allow running against local code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npm run test
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /.env
 /playwright
 /.eslintcache
+/.DS_Store

--- a/README.md
+++ b/README.md
@@ -29,8 +29,39 @@ HMPPS_AUTH_PASSWORD= # A valid HMPPS Auth Password
 
 ## Running the tests
 
-To run the tests locally, run the following command:
+### Against the Development environment
+
+To run the tests locally against the MoJ Cloud Platform Development
+environment, run the following command:
 
 ```bash
 npm run test
 ```
+
+or;
+
+```bash
+npm run test:ui
+```
+
+To run using the Playwright user interface
+
+### Against your local enviroment
+
+Assuming you have the UI, API and all other required systems running
+using the [ap-tools project](https://github.com/ministryofjustice/hmpps-approved-premises-tools),
+you can run the tests against your local environment with the following command:
+
+```bash
+npm run test:local
+```
+
+or;
+
+```bash
+npm run test:local:ui
+```
+
+To run using the Playwright user interface.
+
+Local variables are contained in the `local` project in [playwright.config.ts](https://github.com/ministryofjustice/hmpps-approved-premises-e2e/blob/main/playwright.config.ts).

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "lint": "eslint . --cache --max-warnings 0 ",
     "lint:fix": "eslint . --cache --max-warnings 0 --fix",
-    "test": "npx playwright test",
-    "test:ui": "npx playwright test --ui",
+    "test": "npx playwright test --project=setupDev --project=dev",
+    "test:ui": "npm run test -- --ui",
+    "test:local": "npx playwright test --project=setupLocal --project=local",
+    "test:local:ui": "npm run test:local -- --ui",
     "install-playwright": "npx playwright install"
   },
   "keywords": [],

--- a/pages/apply/crnPage.ts
+++ b/pages/apply/crnPage.ts
@@ -1,8 +1,8 @@
 import { BasePage } from '../basePage'
 
 export class CRNPage extends BasePage {
-  async enterCrn() {
-    await this.page.getByLabel("Enter the person's CRN").fill('X371199')
+  async enterCrn(crn: string) {
+    await this.page.getByLabel("Enter the person's CRN").fill(crn)
   }
 
   async clickSearch() {

--- a/pages/assess/listPage.ts
+++ b/pages/assess/listPage.ts
@@ -1,7 +1,7 @@
 import { BasePage } from '../basePage'
 
 export class ListPage extends BasePage {
-  async clickFirstAssessment() {
-    await this.page.getByRole('link', { name: 'Ben Davies' }).first().click()
+  async clickFirstAssessment(personName: string) {
+    await this.page.getByRole('link', { name: personName }).first().click()
   }
 }

--- a/pages/match/listPage.ts
+++ b/pages/match/listPage.ts
@@ -1,7 +1,7 @@
 import { BasePage } from '../basePage'
 
 export class ListPage extends BasePage {
-  async clickFirstPlacementRequest() {
-    await this.page.getByRole('link', { name: 'Ben Davies' }).first().click()
+  async clickFirstPlacementRequest(personName: string) {
+    await this.page.getByRole('link', { name: personName }).first().click()
   }
 }

--- a/pages/workflow/assessmentPage.ts
+++ b/pages/workflow/assessmentPage.ts
@@ -1,7 +1,7 @@
 import { BasePage } from '../basePage'
 
 export class AssessmentPage extends BasePage {
-  async selectStaffMember() {
-    await this.page.locator('select').selectOption('Approved Premises E2ETester')
+  async selectStaffMember(userName: string) {
+    await this.page.locator('select').selectOption(userName)
   }
 }

--- a/pages/workflow/placementRequestPage.ts
+++ b/pages/workflow/placementRequestPage.ts
@@ -1,7 +1,7 @@
 import { BasePage } from '../basePage'
 
 export class PlacementRequestPage extends BasePage {
-  async selectStaffMember() {
-    await this.page.locator('select').selectOption('Approved Premises E2ETester')
+  async selectStaffMember(userName: string) {
+    await this.page.locator('select').selectOption(userName)
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config'
 import { defineConfig, devices } from '@playwright/test'
+import { TestOptions } from './testOptions'
 
-export default defineConfig({
+export default defineConfig<TestOptions>({
   testDir: './tests',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
@@ -11,15 +12,52 @@ export default defineConfig({
   reporter: 'html',
   timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,
   use: {
-    baseURL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk',
     trace: 'on-first-retry',
     video: 'on-first-retry',
   },
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'], storageState: 'playwright/.auth/user.json' },
+      name: 'setupDev',
+      testMatch: /.*\.setup\.ts/,
+      use: { baseURL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk' },
+    },
+    {
+      name: 'dev',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+        baseURL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk',
+      },
+      dependencies: ['setupDev'],
+    },
+    { name: 'setupLocal', testMatch: /.*\.setup\.ts/, use: { baseURL: 'http://localhost:3000' } },
+    {
+      name: 'local',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+        baseURL: 'http://localhost:3000',
+        person: {
+          name: 'Aadland Bertrand',
+          crn: 'X320741',
+        },
+        user: {
+          name: 'JIM SNOW',
+          username: 'jimsnowldap',
+          password: 'secret',
+        },
+        indexOffenceRequired: true,
+        oasysSections: [
+          '5. Finance',
+          '6. Relationships',
+          '7. Lifestyle',
+          '10. Emotional',
+          '11. Thinking and behavioural',
+          '12. Attitude',
+          '13. Health',
+        ],
+      },
+      dependencies: ['setupLocal'],
     },
   ],
 })

--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -28,16 +28,21 @@ export const startAnApplication = async (dashboard: DashboardPage, page: Page) =
   await startPage.createApplication()
 }
 
-export const enterAndConfirmCrn = async (page: Page) => {
+export const enterAndConfirmCrn = async (page: Page, crn: string, indexOffenceRequired: boolean) => {
   const crnPage = new CRNPage(page)
-  await crnPage.enterCrn()
+  await crnPage.enterCrn(crn)
   await crnPage.clickSave()
 
   const confirmPersonPage = new ConfirmPersonPage(page)
   await confirmPersonPage.clickSave()
+
+  if (indexOffenceRequired) {
+    await page.getByLabel('Select Murder - Murder of infants under 1 year of age as index offence').click()
+    await confirmPersonPage.clickSave()
+  }
 }
 
-export const completeBasicInformationTask = async (page: Page) => {
+export const completeBasicInformationTask = async (page: Page, personName: string) => {
   const notEligiblePage = await ApplyPage.initialize(page, 'This application is not eligible')
   await notEligiblePage.checkRadio('Yes')
   await notEligiblePage.clickSave()
@@ -54,7 +59,7 @@ export const completeBasicInformationTask = async (page: Page) => {
 
   const transgenderPage = await ApplyPage.initialize(
     page,
-    'Is Ben Davies transgender or do they have a transgender history?',
+    `Is ${personName} transgender or do they have a transgender history?`,
   )
   await transgenderPage.checkRadio('No')
   await transgenderPage.clickSave()
@@ -70,7 +75,7 @@ export const completeBasicInformationTask = async (page: Page) => {
   await releaseTypePage.checkRadio('Licence')
   await releaseTypePage.clickSave()
 
-  const releaseDatePage = await ApplyPage.initialize(page, 'Do you know Ben Davies’s release date?')
+  const releaseDatePage = await ApplyPage.initialize(page, `Do you know ${personName}’s release date?`)
   await releaseDatePage.checkRadio('Yes')
   await releaseDatePage.fillReleaseDateField()
   await releaseDatePage.clickSave()
@@ -84,21 +89,21 @@ export const completeBasicInformationTask = async (page: Page) => {
   await purposePage.clickSave()
 }
 
-export const completeTypeOfApTask = async (page: Page) => {
+export const completeTypeOfApTask = async (page: Page, personName: string) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Type of AP required')
 
-  const typeOfApPage = await ApplyPage.initialize(page, 'Which type of AP does Ben Davies require?')
+  const typeOfApPage = await ApplyPage.initialize(page, `Which type of AP does ${personName} require?`)
   await typeOfApPage.checkRadio('Standard AP')
   await typeOfApPage.clickSave()
 }
 
-export const completeOasysImportTask = async (page: Page) => {
+export const completeOasysImportTask = async (page: Page, oasysSections: Array<string>) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Choose sections of OASys to import')
 
   const oasysPage = await ApplyPage.initialize(page, 'Which of the following sections of OASys do you want to import?')
-  await oasysPage.checkCheckBoxes(['3. Accommodation', '13. Health', '4. Education, training and employment'])
+  await oasysPage.checkCheckBoxes(oasysSections)
   await oasysPage.clickSave()
 
   const roshSummaryPage = await ApplyPage.initialize(page)
@@ -117,7 +122,7 @@ export const completeOasysImportTask = async (page: Page) => {
   await riskToSelfPage.clickSave()
 }
 
-export const completeRisksAndNeedsTask = async (page: Page) => {
+export const completeRisksAndNeedsTask = async (page: Page, personName: string) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Add detail about managing risks and needs')
 
@@ -126,7 +131,7 @@ export const completeRisksAndNeedsTask = async (page: Page) => {
     'What features of an Approved Premises (AP) will support the management of risk?',
   )
   await riskManagementFeaturesPage.fillField(
-    'Describe why an AP placement is needed to manage the risk of Ben Davies',
+    `Describe why an AP placement is needed to manage the risk of ${personName}`,
     'Some text',
   )
   await riskManagementFeaturesPage.fillField(
@@ -137,7 +142,7 @@ export const completeRisksAndNeedsTask = async (page: Page) => {
 
   const convictedOffencesPage = await ApplyPage.initialize(
     page,
-    'Has Ben Davies ever been convicted of the following offences?',
+    `Has ${personName} ever been convicted of the following offences?`,
   )
   await convictedOffencesPage.checkRadio('No')
   await convictedOffencesPage.clickSave()
@@ -185,25 +190,25 @@ export const completeLocationFactorsTask = async (page: Page) => {
   await locationFactorsPage.clickSave()
 }
 
-export const completeAccessCulturalAndHealthcareTask = async (page: Page) => {
+export const completeAccessCulturalAndHealthcareTask = async (page: Page, personName: string) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Add access, cultural and healthcare needs')
 
   const accessNeedsPage = await ApplyPage.initialize(page, 'Access, cultural and healthcare needs')
   await accessNeedsPage.checkCheckBoxes(['None of the above'])
-  await accessNeedsPage.checkRadioInGroup('Does Ben Davies have any religious or cultural needs?', 'No')
-  await accessNeedsPage.checkRadioInGroup('Does Ben Davies need an interpreter?', 'No')
+  await accessNeedsPage.checkRadioInGroup(`Does ${personName} have any religious or cultural needs?`, 'No')
+  await accessNeedsPage.checkRadioInGroup(`Does ${personName} need an interpreter?`, 'No')
   await accessNeedsPage.checkRadioInGroup('Does this person have care and support needs?', 'No')
   await accessNeedsPage.checkRadioInGroup('Has a care act assessment been completed?', 'No')
   await accessNeedsPage.clickSave()
 
   const covidPage = await ApplyPage.initialize(page, 'COVID information')
-  await covidPage.checkRadioInGroup('Has Ben Davies been fully vaccinated for COVID-19?', 'No')
-  await covidPage.checkRadioInGroup('Is Ben Davies at a higher risk from COVID-19 based on the NHS guidance?', 'No')
+  await covidPage.checkRadioInGroup(`Has ${personName} been fully vaccinated for COVID-19?`, 'No')
+  await covidPage.checkRadioInGroup(`Is ${personName} at a higher risk from COVID-19 based on the NHS guidance?`, 'No')
   await covidPage.clickSave()
 }
 
-export const completeFurtherConsiderationsTask = async (page: Page) => {
+export const completeFurtherConsiderationsTask = async (page: Page, personName: string) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Detail further considerations for placement')
 
@@ -227,11 +232,11 @@ export const completeFurtherConsiderationsTask = async (page: Page) => {
 
   const vulnerabilityPage = await ApplyPage.initialize(page, 'Vulnerability')
   await vulnerabilityPage.checkRadioInGroup(
-    'Are you aware that Ben Davies is vulnerable to exploitation from others?',
+    `Are you aware that ${personName} is vulnerable to exploitation from others?`,
     'No',
   )
   await vulnerabilityPage.checkRadioInGroup(
-    'Is there any evidence or expectation that Ben Davies may groom, radicalise or exploit others?',
+    `Is there any evidence or expectation that ${personName} may groom, radicalise or exploit others?`,
     'No',
   )
   await vulnerabilityPage.clickSave()
@@ -254,7 +259,7 @@ export const completeFurtherConsiderationsTask = async (page: Page) => {
   await additionalCircumstancesPage.clickSave()
 }
 
-export const completeMoveOnTask = async (page: Page) => {
+export const completeMoveOnTask = async (page: Page, personName: string) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Add move on information')
 
@@ -263,7 +268,7 @@ export const completeMoveOnTask = async (page: Page) => {
   await placementDurationPage.clickSave()
 
   const moveOnPage = await ApplyPage.initialize(page, 'Placement duration and move on')
-  await moveOnPage.fillField('Where is Ben Davies most likely to live when they move on from the AP?', 'WS1')
+  await moveOnPage.fillField(`Where is ${personName} most likely to live when they move on from the AP?`, 'WS1')
   await moveOnPage.clickSave()
 
   const moveOnArrangementsPage = await ApplyPage.initialize(page, 'Placement duration and move on')

--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -2,12 +2,12 @@ import { Page } from '@playwright/test'
 import { AssessPage, ConfirmationPage, ListPage, TasklistPage } from '../pages/assess'
 import { visitDashboard } from './apply'
 
-export const startAssessment = async (page: Page) => {
+export const startAssessment = async (page: Page, personName: string) => {
   const dashboard = await visitDashboard(page)
   await dashboard.clickAssess()
 
   const listPage = new ListPage(page)
-  await listPage.clickFirstAssessment()
+  await listPage.clickFirstAssessment(personName)
 }
 
 export const reviewApplication = async (page: Page) => {

--- a/steps/match.ts
+++ b/steps/match.ts
@@ -2,12 +2,12 @@ import { Page } from '@playwright/test'
 import { visitDashboard } from './apply'
 import { ConfirmPage, ConfirmationPage, DetailsPage, ListPage, ResultsPage } from '../pages/match'
 
-export const searchForBed = async (page: Page) => {
+export const searchForBed = async (page: Page, personName: string) => {
   const dashboard = await visitDashboard(page)
   await dashboard.clickMatch()
 
   const listPage = new ListPage(page)
-  await listPage.clickFirstPlacementRequest()
+  await listPage.clickFirstPlacementRequest(personName)
 
   const detailsPage = new DetailsPage(page)
   await detailsPage.clickSearch()

--- a/steps/workflow.ts
+++ b/steps/workflow.ts
@@ -2,24 +2,24 @@ import { Page } from '@playwright/test'
 import { DashboardPage } from '../pages/dashboardPage'
 import { AssessmentPage, ListPage, PlacementRequestPage } from '../pages/workflow'
 
-export const assignAssessmentToMe = async (dashboard: DashboardPage, page: Page) => {
+export const assignAssessmentToMe = async (dashboard: DashboardPage, page: Page, userName: string) => {
   await dashboard.clickWorkflow()
 
   const workflowListPage = new ListPage(page)
   await workflowListPage.chooseFirstAssessment()
 
   const assessmentPage = new AssessmentPage(page)
-  await assessmentPage.selectStaffMember()
+  await assessmentPage.selectStaffMember(userName)
   await assessmentPage.clickSubmit()
 }
 
-export const assignPlacementRequestToMe = async (dashboard: DashboardPage, page: Page) => {
+export const assignPlacementRequestToMe = async (dashboard: DashboardPage, page: Page, userName: string) => {
   await dashboard.clickWorkflow()
 
   const workflowListPage = new ListPage(page)
   await workflowListPage.chooseFirstPlacementRequest()
 
   const placementRequestPage = new PlacementRequestPage(page)
-  await placementRequestPage.selectStaffMember()
+  await placementRequestPage.selectStaffMember(userName)
   await placementRequestPage.clickSubmit()
 }

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,23 @@
+import { test as base } from '@playwright/test'
+
+import { TestOptions } from './testOptions'
+
+export const test = base.extend<TestOptions>({
+  person: [
+    {
+      name: 'Ben Davies',
+      crn: 'X371199',
+    },
+    { option: true },
+  ],
+  user: [
+    {
+      name: 'Approved Premises E2ETester',
+      username: process.env.HMPPS_AUTH_USERNAME as string,
+      password: process.env.HMPPS_AUTH_PASSWORD as string,
+    },
+    { option: true },
+  ],
+  indexOffenceRequired: [false, { option: true }],
+  oasysSections: [['3. Accommodation', '13. Health', '4. Education, training and employment'], { option: true }],
+})

--- a/testOptions.ts
+++ b/testOptions.ts
@@ -1,0 +1,13 @@
+export type TestOptions = {
+  person: {
+    crn: string
+    name: string
+  }
+  user: {
+    name: string
+    username: string
+    password: string
+  }
+  indexOffenceRequired: boolean
+  oasysSections: Array<string>
+}

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '../test'
 import {
   checkApplyAnswers,
   completeAccessCulturalAndHealthcareTask,
@@ -32,7 +32,7 @@ import {
 } from '../steps/assess'
 import { chooseBed, confirmBooking, searchForBed, shouldShowBookingConfirmation } from '../steps/match'
 
-test('Apply for an Approved Premises', async ({ page }) => {
+test('Apply for an Approved Premises', async ({ page, person, indexOffenceRequired, oasysSections }) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
@@ -40,19 +40,19 @@ test('Apply for an Approved Premises', async ({ page }) => {
   await startAnApplication(dashboard, page)
 
   // And I enter and confirm a CRN
-  await enterAndConfirmCrn(page)
+  await enterAndConfirmCrn(page, person.crn, indexOffenceRequired)
 
   // And I complete the basic information Task
-  await completeBasicInformationTask(page)
+  await completeBasicInformationTask(page, person.name)
 
   // And I complete the Type of AP Task
-  await completeTypeOfApTask(page)
+  await completeTypeOfApTask(page, person.name)
 
   // And I complete the Oasys Import Task
-  await completeOasysImportTask(page)
+  await completeOasysImportTask(page, oasysSections)
 
   // And I complete the the Risks and Needs Task
-  await completeRisksAndNeedsTask(page)
+  await completeRisksAndNeedsTask(page, person.name)
 
   // And I complete the prison notes Task
   await completePrisonNotesTask(page)
@@ -61,13 +61,13 @@ test('Apply for an Approved Premises', async ({ page }) => {
   await completeLocationFactorsTask(page)
 
   // And I complete the Access, Cultural and Healthcare Task
-  await completeAccessCulturalAndHealthcareTask(page)
+  await completeAccessCulturalAndHealthcareTask(page, person.name)
 
   // And I complete the Further Considerations Task
-  await completeFurtherConsiderationsTask(page)
+  await completeFurtherConsiderationsTask(page, person.name)
 
   // And I complete the Move On Task
-  await completeMoveOnTask(page)
+  await completeMoveOnTask(page, person.name)
 
   // And I complete the Attach Required Documemts Task
   await completeAttachRequiredDocuments(page)
@@ -82,15 +82,15 @@ test('Apply for an Approved Premises', async ({ page }) => {
   await shouldSeeConfirmationPage(page)
 })
 
-test('Assess an Approved Premises Application', async ({ page }) => {
+test('Assess an Approved Premises Application', async ({ page, user, person }) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
   // And I allocate the assessement to myself
-  await assignAssessmentToMe(dashboard, page)
+  await assignAssessmentToMe(dashboard, page, user.name)
 
   // And I start the assessment
-  await startAssessment(page)
+  await startAssessment(page, person.name)
 
   // And I Review the application
   await reviewApplication(page)
@@ -120,15 +120,15 @@ test('Assess an Approved Premises Application', async ({ page }) => {
   await shouldSeeAssessmentConfirmationScreen(page)
 })
 
-test('Match and book an Approved Premises Application', async ({ page }) => {
+test('Match and book an Approved Premises Application', async ({ page, user, person }) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
   // And I allocate the placement request to myself
-  await assignPlacementRequestToMe(dashboard, page)
+  await assignPlacementRequestToMe(dashboard, page, user.name)
 
   // And I search for a bed
-  await searchForBed(page)
+  await searchForBed(page, person.name)
 
   // And I select a matching bed
   await chooseBed(page)

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,11 +1,11 @@
-import { test as setup } from '@playwright/test'
+import { test as setup } from '../test'
 
 const authFile = 'playwright/.auth/user.json'
 
-setup('authenticate', async ({ page }) => {
+setup('authenticate', async ({ page, user }) => {
   await page.goto('/')
-  await page.getByLabel('Username').fill(process.env.HMPPS_AUTH_USERNAME as string)
-  await page.getByLabel('Password').fill(process.env.HMPPS_AUTH_PASSWORD as string)
+  await page.getByLabel('Username').fill(user.username)
+  await page.getByLabel('Password').fill(user.password)
   await page.getByRole('button', { name: 'Sign in' }).click()
 
   await page.context().storageState({ path: authFile })

--- a/tests/manage.spec.ts
+++ b/tests/manage.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '../test'
 import { visitDashboard } from '../steps/apply'
 import { PremisesListPage } from '../pages/manage/premisesListPage'
 import { PremisesPage } from '../pages/manage/premisesPage'
@@ -53,7 +53,7 @@ const navigateToTodaysBooking = async page => {
   await premisesPage.clickManageTodaysArrival()
 }
 
-const manuallyBookBed = async page => {
+const manuallyBookBed = async ({ page, person }) => {
   const bedsPage = await navigateToBedsPage(page)
 
   // Given I am on the rooms view page
@@ -69,7 +69,7 @@ const manuallyBookBed = async page => {
   // Given I am on the CRN entry page
   const crnPage = new CRNPage(page)
   // When I enter a CRN
-  await crnPage.enterCrn()
+  await crnPage.enterCrn(person.crn)
   await crnPage.clickSearch()
 
   // Then I should see the placement page
@@ -84,7 +84,7 @@ const manuallyBookBed = async page => {
   await confirmationPage.shouldShowPlacementSuccessMessage()
 }
 
-test('Manually book a bed', async ({ page }) => {
+test('Manually book a bed', async ({ page, person }) => {
   const bedsPage = await navigateToBedsPage(page)
 
   // Given I am on the rooms view page
@@ -100,7 +100,7 @@ test('Manually book a bed', async ({ page }) => {
   // Given I am on the CRN entry page
   const crnPage = new CRNPage(page)
   // When I enter a CRN
-  await crnPage.enterCrn()
+  await crnPage.enterCrn(person.crn)
   await crnPage.clickSearch()
 
   // Then I should see the placement page
@@ -136,9 +136,9 @@ test('Mark a booking as cancelled', async ({ page }) => {
   await placementPage.showsCancellationLoggedMessage()
 })
 
-test('Extend a booking', async ({ page }) => {
+test('Extend a booking', async ({ page, person }) => {
   // Given there is a placement for today
-  await manuallyBookBed(page)
+  await manuallyBookBed({ page, person })
   await navigateToTodaysBooking(page)
   // And I am on the placement's page
   const placementPage = await PlacementPage.initialize(page, 'Placement details')
@@ -188,10 +188,10 @@ test('Mark a bed as lost', async ({ page }) => {
   await premisesPage.showsLostBedLoggedMessage()
 })
 
-test('Mark a booking as arrived ', async ({ page }) => {
+test('Mark a booking as arrived ', async ({ page, person }) => {
   // Given there is a placement for today
   // And I am on the premises's page
-  await manuallyBookBed(page)
+  await manuallyBookBed({ page, person })
   await navigateToTodaysBooking(page)
 
   const placementPage = await PlacementPage.initialize(page, 'Placement details')


### PR DESCRIPTION
This adds a new `local` project, which overrides the baseURL of the main config, and also specifies different CRNs, logins, and other assorted variables which differ between the dev and local environments.

We can now run the e2es against local code, which will allow us to debug failures more easily and get ahead of any changes which might break our e2e tests.