### PR TITLE
Add placement application flow

### DIFF
--- a/pages/apply/listPage.ts
+++ b/pages/apply/listPage.ts
@@ -4,4 +4,17 @@ export class ListPage extends BasePage {
   async startApplication() {
     await this.page.getByRole('button', { name: 'Start now' }).click()
   }
+
+  async clickSubmitted(): Promise<void> {
+    await this.page.getByRole('tab', { name: 'Submitted' }).click()
+  }
+
+  async clickApplicationWithId(applicationId: string): Promise<void> {
+    await this.page
+      .getByRole('row')
+      .filter({ has: this.page.locator(`[data-cy-id="${applicationId}"]`) })
+      .first()
+      .getByRole('link')
+      .click()
+  }
 }

--- a/pages/apply/placementConfirmPage.ts
+++ b/pages/apply/placementConfirmPage.ts
@@ -1,0 +1,8 @@
+import { expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class PlacementConfirmPage extends BasePage {
+  async shouldShowSuccessMessage() {
+    await expect(this.page.locator('h1.govuk-panel__title')).toContainText('Request for placement confirmed')
+  }
+}

--- a/pages/apply/showPage.ts
+++ b/pages/apply/showPage.ts
@@ -1,0 +1,7 @@
+import { BasePage } from '../basePage'
+
+export class ShowPage extends BasePage {
+  async createPlacementRequest(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Create placement request', exact: true }).click()
+  }
+}

--- a/pages/assess/listPage.ts
+++ b/pages/assess/listPage.ts
@@ -4,4 +4,13 @@ export class ListPage extends BasePage {
   async clickFirstAssessment(personName: string) {
     await this.page.getByRole('link', { name: personName }).first().click()
   }
+
+  async clickAssessmentWithApplicationId(applicationId: string) {
+    await this.page
+      .getByRole('row')
+      .filter({ has: this.page.locator(`[data-cy-applicationid="${applicationId}"]`) })
+      .first()
+      .getByRole('link')
+      .click()
+  }
 }

--- a/pages/basePage.ts
+++ b/pages/basePage.ts
@@ -43,8 +43,8 @@ export class BasePage {
   }
 
   async fillDateField({ year, month, day }: { year: string; month: string; day: string }) {
-    await this.page.getByLabel('Day').fill(day)
-    await this.page.getByLabel('Month').fill(month)
-    await this.page.getByLabel('Year').fill(year)
+    await this.page.getByLabel('Day', { exact: true }).fill(day)
+    await this.page.getByLabel('Month', { exact: true }).fill(month)
+    await this.page.getByLabel('Year', { exact: true }).fill(year)
   }
 }

--- a/pages/match/listPage.ts
+++ b/pages/match/listPage.ts
@@ -4,4 +4,17 @@ export class ListPage extends BasePage {
   async clickFirstPlacementRequest(personName: string) {
     await this.page.getByRole('link', { name: personName }).first().click()
   }
+
+  async clickPlacementApplicationWithId(id: string) {
+    await this.page
+      .getByRole('row')
+      .filter({ has: this.page.locator(`[data-cy-applicationId="${id}"]`) })
+      .first()
+      .getByRole('link')
+      .click()
+  }
+
+  async clickPlacementApplications() {
+    await this.page.getByRole('tab', { name: 'Placement Applications' }).click()
+  }
 }

--- a/pages/workflow/listPage.ts
+++ b/pages/workflow/listPage.ts
@@ -1,6 +1,26 @@
 import { BasePage } from '../basePage'
 
 export class ListPage extends BasePage {
+  async chooseAssessmentWithId(id: string) {
+    const assessmentRows = this.page.getByRole('row').filter({ has: this.page.getByText('Assessment') })
+
+    await assessmentRows
+      .filter({ has: this.page.locator(`[data-cy-taskid="${id}"]`) })
+      .first()
+      .getByRole('link')
+      .click()
+  }
+
+  async choosePlacementApplicationWithId(id: string) {
+    const assessmentRows = this.page.getByRole('row').filter({ has: this.page.getByText('Placement application') })
+
+    await assessmentRows
+      .filter({ has: this.page.locator(`[data-cy-taskid="${id}"]`) })
+      .first()
+      .getByRole('link')
+      .click()
+  }
+
   async chooseFirstAssessment() {
     await this.page
       .getByRole('row')
@@ -14,6 +34,16 @@ export class ListPage extends BasePage {
     await this.page
       .getByRole('row')
       .filter({ has: this.page.getByText('Placement request') })
+      .first()
+      .getByRole('link')
+      .click()
+  }
+
+  async choosePlacementRequestWithId(id: string) {
+    const assessmentRows = this.page.getByRole('row').filter({ has: this.page.getByText('Placement request') })
+
+    await assessmentRows
+      .filter({ has: this.page.locator(`[data-cy-taskid="${id}"]`) })
       .first()
       .getByRole('link')
       .click()

--- a/pages/workflow/placementApplicationPage.ts
+++ b/pages/workflow/placementApplicationPage.ts
@@ -1,0 +1,7 @@
+import { BasePage } from '../basePage'
+
+export class PlacementApplicationPage extends BasePage {
+  async selectStaffMember(userName: string) {
+    await this.page.locator('select').selectOption(userName)
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,18 @@ export default defineConfig<TestOptions>({
       },
       dependencies: ['setupDev'],
     },
-    { name: 'setupLocal', testMatch: /.*\.setup\.ts/, use: { baseURL: 'http://localhost:3000' } },
+    {
+      name: 'setupLocal',
+      testMatch: /.*\.setup\.ts/,
+      use: {
+        baseURL: 'http://localhost:3000',
+        user: {
+          name: 'JIM SNOW',
+          username: 'jimsnowldap',
+          password: 'secret',
+        },
+      },
+    },
     {
       name: 'local',
       use: {

--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -1,13 +1,14 @@
 import { Page } from '@playwright/test'
 import { AssessPage, ConfirmationPage, ListPage, TasklistPage } from '../pages/assess'
 import { visitDashboard } from './apply'
+import { assignAssessmentToMe } from './workflow'
 
-export const startAssessment = async (page: Page, personName: string) => {
+export const startAssessment = async (page: Page, personName: string, applicationId: string) => {
   const dashboard = await visitDashboard(page)
   await dashboard.clickAssess()
 
   const listPage = new ListPage(page)
-  await listPage.clickFirstAssessment(personName)
+  await listPage.clickAssessmentWithApplicationId(applicationId)
 }
 
 export const reviewApplication = async (page: Page) => {
@@ -121,4 +122,42 @@ export const submitAssessment = async (page: Page) => {
 export const shouldSeeAssessmentConfirmationScreen = async (page: Page) => {
   const confirmationPage = new ConfirmationPage(page)
   await confirmationPage.shouldShowSuccessMessage()
+}
+
+export const assessApplication = async ({ page, user, person }, applicationId: string) => {
+  // Given I visit the Dashboard
+  const dashboard = await visitDashboard(page)
+
+  // And I allocate the assessement to myself
+  await assignAssessmentToMe(dashboard, page, user.name, applicationId)
+
+  // And I start the assessment
+  await startAssessment(page, person.name, applicationId)
+
+  // And I Review the application
+  await reviewApplication(page)
+
+  // And I confirm there is enough information in the Assessment
+  await confirmInformation(page)
+
+  // And I assess the suitablity of the Application
+  await assessSuitability(page)
+
+  // And I provide the requirements to support the placement
+  await provideRequirements(page)
+
+  // And I make a decision
+  await makeDecision(page)
+
+  // And I provide matching information
+  await addMatchingInformation(page)
+
+  // And I check my answers
+  await checkAssessAnswers(page)
+
+  // And I submit my Assessment
+  await submitAssessment(page)
+
+  // Then I should see a confirmation screen
+  await shouldSeeAssessmentConfirmationScreen(page)
 }

--- a/steps/match.ts
+++ b/steps/match.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test'
 import { visitDashboard } from './apply'
 import { ConfirmPage, ConfirmationPage, DetailsPage, ListPage, ResultsPage } from '../pages/match'
+import { assignPlacementRequestToMe } from './workflow'
 
 export const searchForBed = async (page: Page, personName: string) => {
   const dashboard = await visitDashboard(page)
@@ -26,4 +27,24 @@ export const confirmBooking = async (page: Page) => {
 export const shouldShowBookingConfirmation = async (page: Page) => {
   const confirmationPage = new ConfirmationPage(page)
   await confirmationPage.shouldShowSuccessMessage()
+}
+
+export const matchAndBookApplication = async ({ page, user, person }, id: string) => {
+  // Given I visit the Dashboard
+  const dashboard = await visitDashboard(page)
+
+  // And I allocate the placement request to myself
+  await assignPlacementRequestToMe(dashboard, page, user.name, id)
+
+  // And I search for a bed
+  await searchForBed(page, person.name)
+
+  // And I select a matching bed
+  await chooseBed(page)
+
+  // And I confirm my booking
+  await confirmBooking(page)
+
+  // Then I should bee a confirmation screen
+  await shouldShowBookingConfirmation(page)
 }

--- a/steps/placementApplication.ts
+++ b/steps/placementApplication.ts
@@ -1,0 +1,115 @@
+import { Page } from '@playwright/test'
+import { ApplyPage, DashboardPage, ListPage } from '../pages/apply'
+import { ListPage as WorkflowListPage } from '../pages/workflow'
+import { ListPage as MatchListPage } from '../pages/match'
+import { PlacementConfirmPage } from '../pages/apply/placementConfirmPage'
+import { ShowPage } from '../pages/apply/showPage'
+import { visitDashboard } from './apply'
+import { PlacementApplicationPage } from '../pages/workflow/placementApplicationPage'
+
+export const assignPlacementApplicationToMe = async (
+  dashboard: DashboardPage,
+  page: Page,
+  userName: string,
+  id: string,
+) => {
+  await dashboard.clickWorkflow()
+
+  const workflowListPage = new WorkflowListPage(page)
+  await workflowListPage.choosePlacementApplicationWithId(id)
+
+  const placementRequestPage = new PlacementApplicationPage(page)
+  await placementRequestPage.selectStaffMember(userName)
+  await placementRequestPage.clickSubmit()
+}
+
+export const startPlacementApplication = async ({ page }, applicationId: string) => {
+  // When I visit the Dashboard
+  const dashboard = await visitDashboard(page)
+
+  await dashboard.clickApply()
+
+  const listPage = new ListPage(page)
+  await listPage.clickSubmitted()
+  await listPage.clickApplicationWithId(applicationId)
+
+  const showPage = new ShowPage(page)
+  await showPage.createPlacementRequest()
+}
+
+export const createPlacementApplication = async ({ page }) => {
+  const reasonForPlacementPage = new ApplyPage(page)
+  await reasonForPlacementPage.checkRadioInGroup(
+    'Why are you requesting a placement?',
+    'Release on Temporary Licence (ROTL)',
+  )
+  await reasonForPlacementPage.clickSubmit()
+
+  const previousPlacementPage = new ApplyPage(page)
+  await previousPlacementPage.checkRadioInGroup(
+    'Has this person previously had a placement at an Approved Premises for ROTL?',
+    'No',
+  )
+  await previousPlacementPage.clickSubmit()
+
+  const sameApPage = new ApplyPage(page)
+  await sameApPage.checkRadioInGroup('Do you want this person to stay in the same Approved Premises (AP)?', 'No')
+  await sameApPage.clickSubmit()
+
+  const datePage = new ApplyPage(page)
+  await datePage.fillReleaseDateField()
+  await datePage.fillField('Weeks', '12')
+  await datePage.fillField('Days', '0')
+  await datePage.clickSubmit()
+
+  const updatesToPlacementPage = new ApplyPage(page)
+  await updatesToPlacementPage.checkRadioInGroup(
+    'Have there been any significant events since the application was assessed?',
+    'No',
+  )
+  await updatesToPlacementPage.checkRadioInGroup(
+    "Has the person's circumstances changed which affect the planned AP placement?",
+    'No',
+  )
+  await updatesToPlacementPage.checkRadioInGroup(
+    "Has the person's risk factors changed since the application was assessed?",
+    'No',
+  )
+  await updatesToPlacementPage.checkRadioInGroup(
+    "Has the person's access or healthcare needs changed since the application was assessed?",
+    'No',
+  )
+  await updatesToPlacementPage.checkRadioInGroup(
+    "Has the person's location factors changed since the application was assessed?",
+    'No',
+  )
+  await updatesToPlacementPage.clickSubmit()
+
+  const checkYourAnswersPage = new ApplyPage(page)
+  await checkYourAnswersPage.checkCheckBoxes([
+    'I confirm the information provided is complete, accurate and up to date.',
+  ])
+  await checkYourAnswersPage.clickSubmit()
+
+  const placementConfirmPage = new PlacementConfirmPage(page)
+  await placementConfirmPage.shouldShowSuccessMessage()
+}
+
+export const startAndCreatePlacementApplication = async ({ page }, applicationId: string) => {
+  await startPlacementApplication({ page }, applicationId)
+  await createPlacementApplication({ page })
+}
+
+export const reviewAndApprovePlacementApplication = async ({ page, user }, applicationId: string) => {
+  const dashboard = await visitDashboard(page)
+  await assignPlacementApplicationToMe(dashboard, page, user.name, applicationId)
+
+  await visitDashboard(page)
+  await dashboard.clickMatch()
+
+  const listPage = new MatchListPage(page)
+  await listPage.clickPlacementApplications()
+  await listPage.clickPlacementApplicationWithId(applicationId)
+
+  // TODO: Review and approve application
+}

--- a/steps/workflow.ts
+++ b/steps/workflow.ts
@@ -2,22 +2,27 @@ import { Page } from '@playwright/test'
 import { DashboardPage } from '../pages/dashboardPage'
 import { AssessmentPage, ListPage, PlacementRequestPage } from '../pages/workflow'
 
-export const assignAssessmentToMe = async (dashboard: DashboardPage, page: Page, userName: string) => {
+export const assignAssessmentToMe = async (dashboard: DashboardPage, page: Page, userName: string, id: string) => {
   await dashboard.clickWorkflow()
 
   const workflowListPage = new ListPage(page)
-  await workflowListPage.chooseFirstAssessment()
+  await workflowListPage.chooseAssessmentWithId(id)
 
   const assessmentPage = new AssessmentPage(page)
   await assessmentPage.selectStaffMember(userName)
   await assessmentPage.clickSubmit()
 }
 
-export const assignPlacementRequestToMe = async (dashboard: DashboardPage, page: Page, userName: string) => {
+export const assignPlacementRequestToMe = async (
+  dashboard: DashboardPage,
+  page: Page,
+  userName: string,
+  id: string,
+) => {
   await dashboard.clickWorkflow()
 
   const workflowListPage = new ListPage(page)
-  await workflowListPage.chooseFirstPlacementRequest()
+  await workflowListPage.choosePlacementRequestWithId(id)
 
   const placementRequestPage = new PlacementRequestPage(page)
   await placementRequestPage.selectStaffMember(userName)

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -17,4 +17,16 @@ test('Apply, assess, match and book an application for an Approved Premises with
   await matchAndBookApplication({ page, user, person }, id)
 })
 
+test('Apply, assess, match and book an application for an Approved Premises without a release date', async ({
+  page,
+  user,
+  person,
+  indexOffenceRequired,
+  oasysSections,
+}) => {
+  const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, false)
+  await assessApplication({ page, user, person }, id)
+  await startAndCreatePlacementApplication({ page }, id)
+  await reviewAndApprovePlacementApplication({ page, user }, id)
+  // TODO: Match and book once approval is done
 })

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -1,141 +1,20 @@
 import { test } from '../test'
-import {
-  checkApplyAnswers,
-  completeAccessCulturalAndHealthcareTask,
-  completeAttachRequiredDocuments,
-  completeBasicInformationTask,
-  completeFurtherConsiderationsTask,
-  completeLocationFactorsTask,
-  completeMoveOnTask,
-  completeOasysImportTask,
-  completePrisonNotesTask,
-  completeRisksAndNeedsTask,
-  completeTypeOfApTask,
-  enterAndConfirmCrn,
-  shouldSeeConfirmationPage,
-  startAnApplication,
-  submitApplication,
-  visitDashboard,
-} from '../steps/apply'
-import { assignAssessmentToMe, assignPlacementRequestToMe } from '../steps/workflow'
-import {
-  addMatchingInformation,
-  assessSuitability,
-  checkAssessAnswers,
-  confirmInformation,
-  makeDecision,
-  provideRequirements,
-  reviewApplication,
-  shouldSeeAssessmentConfirmationScreen,
-  startAssessment,
-  submitAssessment,
-} from '../steps/assess'
-import { chooseBed, confirmBooking, searchForBed, shouldShowBookingConfirmation } from '../steps/match'
+import { createApplication } from '../steps/apply'
+import { assessApplication } from '../steps/assess'
+import { matchAndBookApplication } from '../steps/match'
 
-test('Apply for an Approved Premises', async ({ page, person, indexOffenceRequired, oasysSections }) => {
-  // Given I visit the Dashboard
-  const dashboard = await visitDashboard(page)
+import { reviewAndApprovePlacementApplication, startAndCreatePlacementApplication } from '../steps/placementApplication'
 
-  // And I start an application
-  await startAnApplication(dashboard, page)
-
-  // And I enter and confirm a CRN
-  await enterAndConfirmCrn(page, person.crn, indexOffenceRequired)
-
-  // And I complete the basic information Task
-  await completeBasicInformationTask(page, person.name)
-
-  // And I complete the Type of AP Task
-  await completeTypeOfApTask(page, person.name)
-
-  // And I complete the Oasys Import Task
-  await completeOasysImportTask(page, oasysSections)
-
-  // And I complete the the Risks and Needs Task
-  await completeRisksAndNeedsTask(page, person.name)
-
-  // And I complete the prison notes Task
-  await completePrisonNotesTask(page)
-
-  // And I complete the Location Factors Task
-  await completeLocationFactorsTask(page)
-
-  // And I complete the Access, Cultural and Healthcare Task
-  await completeAccessCulturalAndHealthcareTask(page, person.name)
-
-  // And I complete the Further Considerations Task
-  await completeFurtherConsiderationsTask(page, person.name)
-
-  // And I complete the Move On Task
-  await completeMoveOnTask(page, person.name)
-
-  // And I complete the Attach Required Documemts Task
-  await completeAttachRequiredDocuments(page)
-
-  // And I check my answers
-  await checkApplyAnswers(page)
-
-  // And I submit my application
-  await submitApplication(page)
-
-  // Then I should see a confirmation message
-  await shouldSeeConfirmationPage(page)
+test('Apply, assess, match and book an application for an Approved Premises with a release date', async ({
+  page,
+  user,
+  person,
+  indexOffenceRequired,
+  oasysSections,
+}) => {
+  const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true)
+  await assessApplication({ page, user, person }, id)
+  await matchAndBookApplication({ page, user, person }, id)
 })
 
-test('Assess an Approved Premises Application', async ({ page, user, person }) => {
-  // Given I visit the Dashboard
-  const dashboard = await visitDashboard(page)
-
-  // And I allocate the assessement to myself
-  await assignAssessmentToMe(dashboard, page, user.name)
-
-  // And I start the assessment
-  await startAssessment(page, person.name)
-
-  // And I Review the application
-  await reviewApplication(page)
-
-  // And I confirm there is enough information in the Assessment
-  await confirmInformation(page)
-
-  // And I assess the suitablity of the Application
-  await assessSuitability(page)
-
-  // And I provide the requirements to support the placement
-  await provideRequirements(page)
-
-  // And I make a decision
-  await makeDecision(page)
-
-  // And I provide matching information
-  await addMatchingInformation(page)
-
-  // And I check my answers
-  await checkAssessAnswers(page)
-
-  // And I submit my Assessment
-  await submitAssessment(page)
-
-  // Then I should see a confirmation screen
-  await shouldSeeAssessmentConfirmationScreen(page)
-})
-
-test('Match and book an Approved Premises Application', async ({ page, user, person }) => {
-  // Given I visit the Dashboard
-  const dashboard = await visitDashboard(page)
-
-  // And I allocate the placement request to myself
-  await assignPlacementRequestToMe(dashboard, page, user.name)
-
-  // And I search for a bed
-  await searchForBed(page, person.name)
-
-  // And I select a matching bed
-  await chooseBed(page)
-
-  // And I confirm my booking
-  await confirmBooking(page)
-
-  // Then I should bee a confirmation screen
-  await shouldShowBookingConfirmation(page)
 })


### PR DESCRIPTION
This adds support for us to test the application flow for Placement Applications. Because we're creating more than one application now, we'll need to ensure we're working against the correct application, so we fetch the ID of the created application and use the data IDs to fetch the correct Assessments etc.

Sorry the commit history is not as neat as I'd usually like, but hopefully you can follow.