### PR TITLE
Change short notice application to emergency

### DIFF
--- a/pages/apply/applyPage.ts
+++ b/pages/apply/applyPage.ts
@@ -9,12 +9,12 @@ export class ApplyPage extends BasePage {
     return new ApplyPage(page)
   }
 
-  async fillReleaseDateField(shortNotice?: boolean) {
+  async fillReleaseDateField(emergencyApplication?: boolean) {
     const sixMonths = 1000 * 60 * 60 * 24 * 7 * 4 * 6
 
     const nextWeek = 1000 * 60 * 60 * 24 * 8
 
-    const releaseDate = new Date(new Date().getTime() + (shortNotice ? nextWeek : sixMonths))
+    const releaseDate = new Date(new Date().getTime() + (emergencyApplication ? nextWeek : sixMonths))
 
     await this.fillDateField({
       day: releaseDate.getDate().toString(),

--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -47,7 +47,7 @@ export const completeBasicInformationTask = async (
   page: Page,
   personName: string,
   withReleaseDate = true,
-  shortNotice = false,
+  emergencyApplication = false,
 ) => {
   const notEligiblePage = await ApplyPage.initialize(page, 'This application is not eligible')
   await notEligiblePage.checkRadio('Yes')
@@ -89,17 +89,17 @@ export const completeBasicInformationTask = async (
 
   if (withReleaseDate) {
     await releaseDatePage.checkRadio('Yes')
-    await releaseDatePage.fillReleaseDateField(shortNotice)
+    await releaseDatePage.fillReleaseDateField(emergencyApplication)
     await releaseDatePage.clickSave()
 
     const placementDatePage = await ApplyPage.initialize(page)
     await placementDatePage.checkRadio('Yes')
     await placementDatePage.clickSave()
 
-    if (shortNotice) {
-      const shortNoticePage = await ApplyPage.initialize(page, 'Short notice application')
-      await shortNoticePage.checkRadio('The risk level has recently escalated')
-      await shortNoticePage.clickSave()
+    if (emergencyApplication) {
+      const emergencyApplicationPage = await ApplyPage.initialize(page, 'Emergency application')
+      await emergencyApplicationPage.checkRadio('The risk level has recently escalated')
+      await emergencyApplicationPage.clickSave()
     }
   } else {
     await releaseDatePage.checkRadio('No, the release date is to be determined by the parole board or other hearing')
@@ -238,7 +238,11 @@ export const completeAccessCulturalAndHealthcareTask = async (page: Page, person
   await covidPage.clickSave()
 }
 
-export const completeFurtherConsiderationsTask = async (page: Page, personName: string, shortNotice = false) => {
+export const completeFurtherConsiderationsTask = async (
+  page: Page,
+  personName: string,
+  emergencyApplication = false,
+) => {
   const taskListPage = new TasklistPage(page)
   await taskListPage.clickTask('Detail further considerations for placement')
 
@@ -292,7 +296,7 @@ export const completeFurtherConsiderationsTask = async (page: Page, personName: 
   await additionalCircumstancesPage.checkRadio('No')
   await additionalCircumstancesPage.clickSave()
 
-  if (shortNotice) {
+  if (emergencyApplication) {
     const contingencyPlansPage = await ApplyPage.initialize(page, 'Contingency plans')
     await contingencyPlansPage.fillField(
       'If the person does not return to the AP for curfew, what actions should be taken?',
@@ -392,7 +396,7 @@ export const shouldSeeConfirmationPage = async (page: Page) => {
 export const createApplication = async (
   { page, person, indexOffenceRequired, oasysSections },
   withReleaseDate: boolean,
-  shortNotice: boolean,
+  emergencyApplication: boolean,
 ) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
@@ -404,7 +408,7 @@ export const createApplication = async (
   await enterAndConfirmCrn(page, person.crn, indexOffenceRequired)
 
   // And I complete the basic information Task
-  await completeBasicInformationTask(page, person.name, withReleaseDate, shortNotice)
+  await completeBasicInformationTask(page, person.name, withReleaseDate, emergencyApplication)
 
   // And I complete the Type of AP Task
   await completeTypeOfApTask(page, person.name)
@@ -425,7 +429,7 @@ export const createApplication = async (
   await completeAccessCulturalAndHealthcareTask(page, person.name)
 
   // And I complete the Further Considerations Task
-  await completeFurtherConsiderationsTask(page, person.name, shortNotice)
+  await completeFurtherConsiderationsTask(page, person.name, emergencyApplication)
 
   // And I complete the Move On Task
   await completeMoveOnTask(page, person.name)

--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -51,7 +51,7 @@ export const addAdditionalInformation = async (page: Page) => {
   await additionalInformationPage.clickSubmit()
 }
 
-export const assessSuitability = async (page: Page, shortNotice = false) => {
+export const assessSuitability = async (page: Page, emergencyApplication = false) => {
   const tasklistPage = new TasklistPage(page)
   await tasklistPage.clickTask('Assess suitability of application')
 
@@ -68,13 +68,21 @@ export const assessSuitability = async (page: Page, shortNotice = false) => {
   await assessPage.checkRadioInGroup('Is the move on plan sufficient?', 'Yes')
   await assessPage.clickSubmit()
 
-  if (shortNotice) {
+  if (emergencyApplication) {
     const applicationTimelinessPage = await AssessPage.initialize(page, 'Application timeliness')
     await applicationTimelinessPage.checkRadioInGroup(
       "Do you agree with the applicant's reason for submission within 4 months of expected arrival?",
       'Yes',
     )
     await applicationTimelinessPage.clickSubmit()
+
+    const contingencyPlansSufficientPage = await AssessPage.initialize(page, 'Suitability assessment')
+    await contingencyPlansSufficientPage.checkRadioInGroup(
+      'Is the contingency plan sufficient to manage behaviour or a failure to return out of hours?',
+      'Yes',
+    )
+    await contingencyPlansSufficientPage.fillField('Additional comments', 'Some comments')
+    await contingencyPlansSufficientPage.clickSubmit()
   }
 }
 
@@ -155,7 +163,11 @@ export const shouldSeeAssessmentConfirmationScreen = async (page: Page) => {
   await confirmationPage.shouldShowSuccessMessage()
 }
 
-export const assessApplication = async ({ page, user, person }, applicationId: string, shortNotice: boolean) => {
+export const assessApplication = async (
+  { page, user, person },
+  applicationId: string,
+  emergencyApplication: boolean,
+) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
@@ -172,7 +184,7 @@ export const assessApplication = async ({ page, user, person }, applicationId: s
   await confirmInformation(page)
 
   // And I assess the suitablity of the Application
-  await assessSuitability(page, shortNotice)
+  await assessSuitability(page, emergencyApplication)
 
   // And I provide the requirements to support the placement
   await provideRequirements(page)

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -24,7 +24,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
   await matchAndBookApplication({ page, user, person }, id)
 })
 
-test('Apply, assess, match and book a short notice application for an Approved Premises', async ({
+test('Apply, assess, match and book an emergency application for an Approved Premises', async ({
   page,
   user,
   person,


### PR DESCRIPTION
Applications are now treated as Emergency if the release date is 28 days or more away, so we need to update the test flow to test for emergency applications. I've also updated the test name and some of the variables.