### PR TITLE
Ensure a booking is present to mark as nonArrived

### DIFF
--- a/tests/manage.spec.ts
+++ b/tests/manage.spec.ts
@@ -208,9 +208,10 @@ test('Mark a booking as arrived ', async ({ page, person }) => {
   await placementPage.showsArrivalLoggedMessage()
 })
 
-test('Mark a booking as not arrived', async ({ page }) => {
+test('Mark a booking as not arrived', async ({ page, person }) => {
   // Given there is a placement for today
   // And I am on the premises's page
+  await manuallyBookBed({ page, person })
   await navigateToPremisesPage(page)
   const premisesPage = await PremisesPage.initialize(page, premisesName)
 


### PR DESCRIPTION
This adds a call to create a booking at the start of the test to match all the other tests. This was working by accident, as there were bookings to click on before, but something must have got out of sync.