### PR TITLE
Use withdrawl reason instead of Yes/No

### DIFF
--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -462,6 +462,6 @@ export const withdrawAnApplication = async (page: Page) => {
   await page.getByRole('link', { name: 'Withdraw' }).first().click()
 
   const confirmWithdrawalPage = new BasePage(page)
-  await confirmWithdrawalPage.checkRadio('Yes')
+  await confirmWithdrawalPage.checkRadio('Alternative provision identified')
   await confirmWithdrawalPage.clickContinue()
 }


### PR DESCRIPTION
The application withdrawl page has changed now so we need to specify a reason instead of just confirming.