### PR TITLE
Set trace and video to `on`

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,8 +12,8 @@ export default defineConfig<TestOptions>({
   reporter: 'html',
   timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,
   use: {
-    trace: 'on-first-retry',
-    video: 'on-first-retry',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
   },
   projects: [
     {


### PR DESCRIPTION
This will allow us to view videos for failed e2e runs in CI