### PR TITLE
Input real dates when changing placement dates

### DIFF
--- a/pages/manage/arrivalFormPage.ts
+++ b/pages/manage/arrivalFormPage.ts
@@ -30,18 +30,20 @@ export class ArrivalFormPage extends BasePage {
   }
 
   async completeExpectedDepartureDate() {
+    const newDate = addMonths(new Date(), 1)
+
     await this.page
       .getByRole('group', { name: 'What is their expected departure date?' })
       .getByLabel('Day')
-      .fill(getDate(addMonths(new Date(), 1)).toString())
+      .fill(getDate(newDate).toString())
     await this.page
       .getByRole('group', { name: 'What is their expected departure date?' })
       .getByLabel('Month')
-      .fill(getMonth(addMonths(new Date(), 1)).toString())
+      .fill((getMonth(newDate) + 1).toString())
     await this.page
       .getByRole('group', { name: 'What is their expected departure date?' })
       .getByLabel('Year')
-      .fill(getYear(addMonths(new Date(), 1)).toString())
+      .fill(getYear(newDate).toString())
   }
 
   async selectKeyWorker() {

--- a/pages/manage/changeDepartureDate.ts
+++ b/pages/manage/changeDepartureDate.ts
@@ -11,19 +11,18 @@ export class ChangeDepartureDatePage extends BasePage {
   }
 
   async selectAndEnterNewDepartureDate() {
+    const newDate = addMonths(new Date(), 2)
+
     const departureDateLabel = 'What is the new departure date?'
-    await this.page
-      .getByRole('group', { name: departureDateLabel })
-      .getByLabel('Day')
-      .fill(getDate(new Date()).toString())
+    await this.page.getByRole('group', { name: departureDateLabel }).getByLabel('Day').fill(getDate(newDate).toString())
     await this.page
       .getByRole('group', { name: departureDateLabel })
       .getByLabel('Month')
-      .fill(getMonth(addMonths(new Date(), 2)).toString())
+      .fill((getMonth(newDate) + 1).toString())
     await this.page
       .getByRole('group', { name: departureDateLabel })
       .getByLabel('Year')
-      .fill(getYear(new Date()).toString())
+      .fill(getYear(newDate).toString())
   }
 
   async completeForm() {

--- a/pages/manage/changePlacementDates.ts
+++ b/pages/manage/changePlacementDates.ts
@@ -11,35 +11,37 @@ export class ChangePlacementDatesPage extends BasePage {
   }
 
   async selectAndEnterNewArrivalDate() {
+    const newDate = addMonths(new Date(), 2)
     await this.page.getByLabel('Arrival date').check()
     await this.page
       .getByRole('group', { name: 'What is the new arrival date?' })
       .getByLabel('Day')
-      .fill(getDate(new Date()).toString())
+      .fill(getDate(newDate).toString())
     await this.page
       .getByRole('group', { name: 'What is the new arrival date?' })
       .getByLabel('Month')
-      .fill(getMonth(addMonths(new Date(), 2)).toString())
+      .fill((getMonth(newDate) + 1).toString())
     await this.page
       .getByRole('group', { name: 'What is the new arrival date?' })
       .getByLabel('Year')
-      .fill(getYear(new Date()).toString())
+      .fill(getYear(newDate).toString())
   }
 
   async selectAndEnterNewDepartureDate() {
+    const newDate = addMonths(new Date(), 3)
     await this.page.getByLabel('Departure date').check()
     await this.page
       .getByRole('group', { name: 'What is the new departure date?' })
       .getByLabel('Day')
-      .fill(getDate(new Date()).toString())
+      .fill(getDate(newDate).toString())
     await this.page
       .getByRole('group', { name: 'What is the new departure date?' })
       .getByLabel('Month')
-      .fill(getMonth(addMonths(new Date(), 2)).toString())
+      .fill((getMonth(newDate) + 1).toString())
     await this.page
       .getByRole('group', { name: 'What is the new departure date?' })
       .getByLabel('Year')
-      .fill(getYear(new Date()).toString())
+      .fill(getYear(newDate).toString())
   }
 
   async completeForm() {


### PR DESCRIPTION
Before, if the tests ran on a day of the month that doesn’t exist in two month’s time, then we end up entering a date that doesn’t exist.