### PR TITLE
Assign user roles before performing tests

### DIFF
--- a/pages/admin/editUser.ts
+++ b/pages/admin/editUser.ts
@@ -1,6 +1,24 @@
 import { Page, expect } from '@playwright/test'
 import { BasePage } from '../basePage'
 
+export const qualifactions = ['PIPE', 'Emergency APs', 'Limited access offenders', 'ESAP']
+
+export type Qualifaction = (typeof qualifactions)[number]
+
+export const roles = [
+  'Administrator',
+  'Assessor',
+  'Manage an Approved Premises',
+  'Matcher',
+  'Workflow manager',
+  'Stop assessment allocations',
+  'Stop match allocations',
+  'Stop placement request allocations',
+  ...qualifactions,
+] as const
+
+export type Role = (typeof roles)[number]
+
 export class EditUser extends BasePage {
   static async initialize(page: Page) {
     await expect(page.locator('h1')).toContainText('Manage permissions')
@@ -26,13 +44,13 @@ export class EditUser extends BasePage {
     this.page.getByRole('definition', { name: username })
   }
 
-  async assertCheckboxesAreSelected(labels: Array<string>) {
+  async assertCheckboxesAreSelected(labels: ReadonlyArray<Role>) {
     labels.forEach(async label => {
       expect(await this.page.getByLabel(label).isChecked()).toBeTruthy()
     })
   }
 
-  async assertCheckboxesAreUnselected(labels: Array<string>) {
+  async assertCheckboxesAreUnselected(labels: ReadonlyArray<Role>) {
     labels.forEach(async label => {
       expect(await this.page.getByLabel(label).isChecked()).toBeFalsy()
     })

--- a/pages/admin/editUser.ts
+++ b/pages/admin/editUser.ts
@@ -1,9 +1,9 @@
 import { Page, expect } from '@playwright/test'
 import { BasePage } from '../basePage'
 
-export const qualifactions = ['PIPE', 'Emergency APs', 'Limited access offenders', 'ESAP']
+export const qualifications = ['PIPE', 'Emergency APs', 'Limited access offenders', 'ESAP']
 
-export type Qualifaction = (typeof qualifactions)[number]
+export type Qualification = (typeof qualifications)[number]
 
 export const roles = [
   'Administrator',
@@ -14,7 +14,7 @@ export const roles = [
   'Stop assessment allocations',
   'Stop match allocations',
   'Stop placement request allocations',
-  ...qualifactions,
+  ...qualifications,
 ] as const
 
 export type Role = (typeof roles)[number]
@@ -42,6 +42,19 @@ export class EditUser extends BasePage {
     await expect(this.page.locator('h1')).toContainText('Manage permissions')
     await expect(this.page.getByRole('definition')).toHaveCount(5)
     this.page.getByRole('definition', { name: username })
+  }
+
+  async uncheckSelectedQualifications() {
+    const qualifactionsSection = this.page.getByRole('group', { name: 'Select any additional' })
+    const selectedCheckboxes = await qualifactionsSection.getByRole('checkbox', { checked: true }).all()
+
+    const promises = [] as Array<Promise<void>>
+
+    selectedCheckboxes.forEach(async checkbox => {
+      promises.push(checkbox.dispatchEvent('click'))
+    })
+
+    await Promise.all(promises)
   }
 
   async assertCheckboxesAreSelected(labels: ReadonlyArray<Role>) {

--- a/pages/apply/applyPage.ts
+++ b/pages/apply/applyPage.ts
@@ -9,18 +9,19 @@ export class ApplyPage extends BasePage {
     return new ApplyPage(page)
   }
 
-  async fillReleaseDateField(emergencyApplication?: boolean) {
+  async fillReleaseDateField(emergencyApplication = false) {
     const sixMonths = 1000 * 60 * 60 * 24 * 7 * 4 * 6
 
     const nextWeek = 1000 * 60 * 60 * 24 * 8
 
     const releaseDate = new Date(new Date().getTime() + (emergencyApplication ? nextWeek : sixMonths))
-
-    await this.fillDateField({
+    const dateFields = {
       day: releaseDate.getDate().toString(),
       month: (releaseDate.getMonth() + 1).toString(),
       year: releaseDate.getFullYear().toString(),
-    })
+    }
+
+    await this.fillDateField(dateFields)
   }
 
   async fillSedField(date: { day: string; month: string; year: string }) {
@@ -31,5 +32,10 @@ export class ApplyPage extends BasePage {
 
   async clickTab(title: string) {
     await this.page.getByRole('link', { name: title }).click()
+  }
+
+  async fillDurationField({ weeks, days }: { weeks: number; days: number }) {
+    await this.page.getByLabel('Weeks', { exact: true }).first().fill(weeks.toString())
+    await this.page.getByLabel('Days', { exact: true }).first().fill(days.toString())
   }
 }

--- a/pages/basePage.ts
+++ b/pages/basePage.ts
@@ -43,8 +43,8 @@ export class BasePage {
   }
 
   async fillDateField({ year, month, day }: { year: string; month: string; day: string }) {
-    await this.page.getByLabel('Day', { exact: true }).fill(day)
-    await this.page.getByLabel('Month', { exact: true }).fill(month)
-    await this.page.getByLabel('Year', { exact: true }).fill(year)
+    await this.page.getByLabel('Day', { exact: true }).first().fill(day)
+    await this.page.getByLabel('Month', { exact: true }).first().fill(month)
+    await this.page.getByLabel('Year', { exact: true }).first().fill(year)
   }
 }

--- a/pages/basePage.ts
+++ b/pages/basePage.ts
@@ -32,7 +32,7 @@ export class BasePage {
       .check()
   }
 
-  async checkCheckBoxes(labels: Array<string>) {
+  async checkCheckBoxes(labels: Array<string> | ReadonlyArray<string>) {
     const promises = [] as Array<Promise<void>>
 
     for (let i = 0; i < labels.length; i += 1) {

--- a/steps/admin.ts
+++ b/steps/admin.ts
@@ -1,0 +1,23 @@
+import { Page } from '@playwright/test'
+import { EditUser, Qualification } from '../pages/admin/editUser'
+import { visitDashboard } from './apply'
+import { UserList } from '../pages/admin/listUsers'
+
+export const setRoles = async (page: Page, roles: ReadonlyArray<Qualification>) => {
+  const dashboard = await visitDashboard(page)
+  dashboard.clickUserMangement()
+
+  const userListPage = await UserList.initialize(page)
+
+  await userListPage.search('Approved Premises E2ETester')
+
+  await userListPage.clickEditUser('Approved Premises E2ETester')
+
+  const usersPage = new EditUser(page)
+
+  await usersPage.uncheckSelectedQualifications()
+
+  await usersPage.checkCheckBoxes(roles)
+
+  await usersPage.clickSave()
+}

--- a/steps/placementApplication.ts
+++ b/steps/placementApplication.ts
@@ -57,9 +57,8 @@ export const createPlacementApplication = async ({ page }) => {
 
   const datePage = new ApplyPage(page)
   await datePage.fillReleaseDateField()
-  await datePage.fillField('Weeks', '12')
-  await datePage.fillField('Days', '0')
-  await datePage.clickSubmit()
+  await datePage.fillDurationField({ weeks: 12, days: 0 })
+  await datePage.clickContinue()
 
   const updatesToPlacementPage = new ApplyPage(page)
   await updatesToPlacementPage.checkRadioInGroup(

--- a/steps/placementApplication.ts
+++ b/steps/placementApplication.ts
@@ -55,10 +55,6 @@ export const createPlacementApplication = async ({ page }) => {
   )
   await previousPlacementPage.clickSubmit()
 
-  const sameApPage = new ApplyPage(page)
-  await sameApPage.checkRadioInGroup('Do you want this person to stay in the same Approved Premises (AP)?', 'No')
-  await sameApPage.clickSubmit()
-
   const datePage = new ApplyPage(page)
   await datePage.fillReleaseDateField()
   await datePage.fillField('Weeks', '12')

--- a/tests/admin.spec.ts
+++ b/tests/admin.spec.ts
@@ -4,7 +4,7 @@ import { visitDashboard } from '../steps/apply'
 import { ReportsPage } from '../pages/admin/reports'
 import { UserList } from '../pages/admin/listUsers'
 import { AddUser } from '../pages/admin/addUser'
-import { EditUser } from '../pages/admin/editUser'
+import { EditUser, roles } from '../pages/admin/editUser'
 import { NewUserConfirmationPage } from '../pages/admin/newUserConfirmationPage'
 import { DeleteUserConfirmationPage } from '../pages/admin/deleteUserConfirmationPage'
 
@@ -62,24 +62,9 @@ test('manage users', async ({ page }) => {
   // Then I should be taken to the Edit User page
   const editUserPage = await EditUser.initialize(page)
 
-  const checkboxes = [
-    'Administrator',
-    'Assessor',
-    'Manage an Approved Premises',
-    'Matcher',
-    'Workflow manager',
-    'Stop assessment allocations',
-    'Stop match allocations',
-    'Stop placement request allocations',
-    'PIPE',
-    'Emergency APs',
-    'Limited access offenders',
-    'ESAP',
-  ]
-
   // When I select all the checkboxes
-  await editUserPage.checkCheckBoxes(checkboxes)
-  await editUserPage.assertCheckboxesAreSelected(checkboxes)
+  await editUserPage.checkCheckBoxes(roles)
+  await editUserPage.assertCheckboxesAreSelected(roles)
 
   // And I click 'Save'
   await editUserPage.clickSave()
@@ -88,11 +73,11 @@ test('manage users', async ({ page }) => {
   await editUserPage.shouldShowUserUpdatedBanner()
 
   // And all the checkboxes should be selected
-  await editUserPage.assertCheckboxesAreSelected(checkboxes)
+  await editUserPage.assertCheckboxesAreSelected(roles)
 
   // When I unselect all the checkboxes
-  await editUserPage.checkCheckBoxes(checkboxes)
-  await editUserPage.assertCheckboxesAreUnselected(checkboxes)
+  await editUserPage.checkCheckBoxes(roles)
+  await editUserPage.assertCheckboxesAreUnselected(roles)
 
   // And I click 'Save'
   await editUserPage.clickSave()
@@ -101,7 +86,7 @@ test('manage users', async ({ page }) => {
   await editUserPage.shouldShowUserUpdatedBanner()
 
   // And all the checkboxes should be selected
-  await editUserPage.assertCheckboxesAreUnselected(checkboxes)
+  await editUserPage.assertCheckboxesAreUnselected(roles)
 
   // When I click 'Remove access'
   await editUserPage.clickRemoveAccess()

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -14,6 +14,7 @@ import { assessApplication, requestAndAddAdditionalInformation } from '../steps/
 import { startAndCreatePlacementApplication, withdrawPlacementApplication } from '../steps/placementApplication'
 
 import { ListPage } from '../pages/apply'
+import { setRoles } from '../steps/admin'
 
 test('Apply, assess, match and book an application for an Approved Premises with a release date', async ({
   page,
@@ -22,6 +23,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
   indexOffenceRequired,
   oasysSections,
 }) => {
+  await setRoles(page, [])
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false, true)
   await assessApplication({ page, user, person }, id, false)
   await withdrawAnApplicationAfterSubmission(page)
@@ -36,6 +38,8 @@ test('Apply, assess, match and book an emergency application for an Approved Pre
   indexOffenceRequired,
   oasysSections,
 }) => {
+  await setRoles(page, ['Emergency APs'])
+
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, true)
   await assessApplication({ page, user, person }, id, true)
   // Skip match until it's back
@@ -49,6 +53,8 @@ test('Apply, assess, match and book an application for an Approved Premises with
   indexOffenceRequired,
   oasysSections,
 }) => {
+  await setRoles(page, [])
+
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, false, false)
   await assessApplication({ page, user, person }, id, false)
   await startAndCreatePlacementApplication({ page }, id)
@@ -81,6 +87,8 @@ test('Request further information on an Application, adds it and proceeds with t
   indexOffenceRequired,
   oasysSections,
 }) => {
+  await setRoles(page, [])
+
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false)
   await requestAndAddAdditionalInformation({ page, user, person }, id)
 })


### PR DESCRIPTION
The E2Es have been failing due to the E2E user not appearing the in the dropdown when assigning an assessment to a user (EG `/tasks/placement-request/{placementRequestId}`). 
For the first Apply test in order to appear in the drop down the user needs to have no 'qualifications' selected from the following list if the Application isn't a special type (Emergency, PIPE, ESAP, LAO) 
![image](https://github.com/ministryofjustice/hmpps-approved-premises-e2e/assets/44123869/41f56909-fafb-45e4-a258-af2b1e467c1c)
But for the second Apply test in order to appear in the drop down the user needs to have the 'emergency' qualification selected from the list
