### PR TITLE
Remove withdrawlTypePage when withdrawing

### DIFF
--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -505,10 +505,6 @@ export const withdrawAnApplicationAfterSubmission = async (page: Page) => {
   await listPage.clickSubmitted()
   await page.getByRole('link', { name: 'Withdraw' }).first().click()
 
-  const withdrawalTypePage = new BasePage(page)
-  await withdrawalTypePage.checkRadio('Application')
-  await withdrawalTypePage.clickContinue()
-
   const confirmWithdrawalPage = new BasePage(page)
   await confirmWithdrawalPage.checkRadio('Error in application')
   await confirmWithdrawalPage.clickContinue()


### PR DESCRIPTION
This showed up when fixing, but in normal circumstances won’t show up, because the application has no associated bookings or placement requests.