### PR TITLE
Click correct withdraw link

### DIFF
--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -496,14 +496,25 @@ export const withdrawAnApplicationBeforeSubmission = async (page: Page) => {
   await confirmWithdrawalPage.clickContinue()
 }
 
-export const withdrawAnApplicationAfterSubmission = async (page: Page) => {
+export const withdrawAnApplicationAfterSubmission = async (page: Page, applicationId: string) => {
   const dashboard = visitDashboard(page)
 
   ;(await dashboard).clickApply()
 
   const listPage = new ListPage(page)
   await listPage.clickSubmitted()
-  await page.getByRole('link', { name: 'Withdraw' }).first().click()
+  await page
+    .getByRole('row')
+    .filter({ has: page.locator(`[data-cy-id="${applicationId}"]`) })
+    .first()
+    .getByRole('link')
+    .filter({ has: page.getByText('Withdraw') })
+    .first()
+    .click()
+
+  const withdrawalTypePage = new BasePage(page)
+  await withdrawalTypePage.checkRadio('Application')
+  await withdrawalTypePage.clickContinue()
 
   const confirmWithdrawalPage = new BasePage(page)
   await confirmWithdrawalPage.checkRadio('Error in application')

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -26,7 +26,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
   await setRoles(page, [])
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false, true)
   await assessApplication({ page, user, person }, id, false)
-  await withdrawAnApplicationAfterSubmission(page)
+  await withdrawAnApplicationAfterSubmission(page, id)
   // Skip match until it's back
   // await matchAndBookApplication({ page, user, person }, id)
 })


### PR DESCRIPTION
Before we were blindly clicking on the first withdraw link, which was not always the correct one, so now we filter by the application’s ID first and click on the link in that row to ensure we withdraw the right application.