### PR TITLE
Fix withdrawal tests

### DIFF
--- a/pages/manage/cancellationPage.ts
+++ b/pages/manage/cancellationPage.ts
@@ -11,7 +11,7 @@ export class CancellationPage extends BasePage {
   }
 
   async enterCancellationDate() {
-    const cancellationLabel = 'When was this placement cancelled?'
+    const cancellationLabel = 'When was this placement withdrawn?'
     await this.page
       .getByRole('group', { name: cancellationLabel })
       .getByLabel('Day')

--- a/pages/manage/placementPage.ts
+++ b/pages/manage/placementPage.ts
@@ -30,7 +30,7 @@ export class PlacementPage extends BasePage {
 
   async clickMarkCancelled() {
     await this.clickActions()
-    await this.page.getByRole('menuitem', { name: 'Cancel placement' }).click()
+    await this.page.getByRole('menuitem', { name: 'Withdraw placement' }).click()
   }
 
   async clickChangePlacementDates() {
@@ -48,7 +48,7 @@ export class PlacementPage extends BasePage {
   }
 
   async showsCancellationLoggedMessage() {
-    await this.page.waitForSelector('text=Booking cancelled')
+    await this.page.waitForSelector('text=Booking withdrawn')
   }
 
   async showsExtensionLoggedMessage() {

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -69,12 +69,12 @@ test('Withdraw an application before submission', async ({ page, person, indexOf
   const dashboard = await visitDashboard(page)
 
   await startAnApplication(dashboard, page)
-  await enterAndConfirmCrn(page, person.crn, indexOffenceRequired)
+  const applicationId = await enterAndConfirmCrn(page, person.crn, indexOffenceRequired)
 
   await visitDashboard(page)
   await dashboard.clickApply()
 
-  await withdrawAnApplicationBeforeSubmission(page)
+  await withdrawAnApplicationBeforeSubmission(page, applicationId)
 
   const listPage = new ListPage(page)
   await listPage.shouldShowWithdrawalConfirmationMessage()

--- a/tests/manage.spec.ts
+++ b/tests/manage.spec.ts
@@ -95,7 +95,7 @@ test('Mark a booking as cancelled', async ({ page }) => {
   await placementPage.clickMarkCancelled()
 
   // Then I should see the cancellation form
-  const cancellationFormPage = await CancellationPage.initialize(page, 'Confirm cancelled placement')
+  const cancellationFormPage = await CancellationPage.initialize(page, 'Confirm withdrawn placement')
 
   // When I complete the form
   await cancellationFormPage.completeForm()


### PR DESCRIPTION
We now show an interstitial page regardless of if there are withdrawables present. I’ve also DRYed up some of the withdrawl helpers and made sure we withdraw the correct application by fetching the ID.