### PR TITLE
Update allocations

### DIFF
--- a/pages/workflow/listPage.ts
+++ b/pages/workflow/listPage.ts
@@ -6,11 +6,17 @@ export class ListPage extends BasePage {
 
     const assessmentRows = this.page.getByRole('row').filter({ has: this.page.getByText('Assessment') })
 
-    await assessmentRows
-      .filter({ has: this.page.locator(`[data-cy-applicationId="${id}"]`) })
-      .first()
-      .getByRole('link')
-      .click()
+    const assessmentRow = await assessmentRows.filter({ has: this.page.locator(`[data-cy-applicationId="${id}"]`) })
+
+    if (!(await assessmentRow.isVisible())) {
+      await this.page
+        .getByRole('link')
+        .filter({ has: this.page.getByText('Unallocated') })
+        .first()
+        .click()
+    }
+
+    await assessmentRow.first().getByRole('link').click()
   }
 
   async choosePlacementApplicationWithId(id: string) {


### PR DESCRIPTION
Now the new allocations engine is enabled in dev, we need to check the assessment is visible when reallocating, if it’s not, we click on the `Unallocated` tab