### PR TITLE
Add test to appeal a decision

### DIFF
--- a/pages/apply/appealApplicationPage.ts
+++ b/pages/apply/appealApplicationPage.ts
@@ -1,0 +1,16 @@
+import { BasePage } from '../basePage'
+
+export class AppealApplicationPage extends BasePage {
+  async fillForm() {
+    await this.fillDateField({ year: '2023', month: '3', day: '12' })
+    await this.fillField('What was the reason for the appeal?', 'Appeal reasons')
+    await this.fillField('Who made the decision on the appeal?', 'Appeal staff details')
+    await this.checkRadio('Upheld')
+    await this.fillField('What are the reasons for the appeal decision?', 'Appeal decision reasons')
+    await this.clickSave()
+  }
+
+  async clickSave(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Save' }).click()
+  }
+}

--- a/pages/apply/listPage.ts
+++ b/pages/apply/listPage.ts
@@ -19,6 +19,16 @@ export class ListPage extends BasePage {
       .click()
   }
 
+  async filterApplicationsBy(option: string) {
+    await this.selectAllApplications()
+    await this.page.getByLabel('Statuses').selectOption({ label: option })
+    await this.page.getByRole('button', { name: 'Apply filters' }).click()
+  }
+
+  async selectAllApplications(): Promise<void> {
+    await this.page.getByRole('link', { name: 'All applications' }).click()
+  }
+
   async shouldShowWithdrawalConfirmationMessage() {
     await expect(this.page.getByRole('alert', { name: 'Success' })).toContainText('Success')
     await expect(this.page.getByRole('heading', { name: 'Application withdrawn' })).toContainText(

--- a/pages/apply/showPage.ts
+++ b/pages/apply/showPage.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import { BasePage } from '../basePage'
+import { AppealApplicationPage } from './appealApplicationPage'
 
 export class ShowPage extends BasePage {
   async createPlacementRequest(): Promise<void> {
@@ -9,6 +10,14 @@ export class ShowPage extends BasePage {
 
   async clickPlacementRequestsTab(): Promise<void> {
     await this.page.getByLabel('Secondary navigation region').getByRole('link', { name: 'Placement requests' }).click()
+  }
+
+  async appealApplication(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Actions' }).click()
+    await this.page.getByRole('menuitem', { name: 'Process an appeal' }).click()
+
+    const appealApplicationPage = new AppealApplicationPage(this.page)
+    await appealApplicationPage.fillForm()
   }
 
   async withdrawPlacementApplication(): Promise<void> {
@@ -28,5 +37,9 @@ export class ShowPage extends BasePage {
     await reasonPage.clickContinue()
 
     expect(this.page.getByRole('heading', { name: 'Placement application withdrawn' })).toBeTruthy()
+  }
+
+  async shouldShowAssessmentReopenedBanner(): Promise<void> {
+    await expect(this.page.getByRole('alert')).toContainText('Assessment reopened')
   }
 }

--- a/pages/assess/confirmationPage.ts
+++ b/pages/assess/confirmationPage.ts
@@ -3,8 +3,6 @@ import { BasePage } from '../basePage'
 
 export class ConfirmationPage extends BasePage {
   async shouldShowSuccessMessage() {
-    await expect(this.page.locator('h1.govuk-panel__title')).toContainText(
-      'You have marked this application as suitable',
-    )
+    await expect(this.page.locator('h1.govuk-panel__title')).toContainText('You have marked this application as')
   }
 }

--- a/steps/apply.ts
+++ b/steps/apply.ts
@@ -13,6 +13,7 @@ import {
 } from '../pages/apply'
 import { BasePage } from '../pages/basePage'
 import { TestOptions } from '../testOptions'
+import { ShowPage } from '../pages/apply/showPage'
 
 export const visitDashboard = async (page: Page): Promise<DashboardPage> => {
   const dashboard = new DashboardPage(page)
@@ -510,6 +511,20 @@ export const withdrawAnApplicationAfterSubmission = async (page: Page, applicati
   await withdrawApplication(page)
 
   await expect(page.getByRole('alert', { name: 'Success' })).toContainText('Success')
+}
+
+export const recordAnAppealOnApplication = async (page: Page, applicationId: string) => {
+  const dashboard = visitDashboard(page)
+
+  ;(await dashboard).clickApply()
+
+  const listPage = new ListPage(page)
+  await listPage.filterApplicationsBy('Application rejected')
+  await listPage.clickApplicationWithId(applicationId)
+
+  const showPage = new ShowPage(page)
+  await showPage.appealApplication()
+  await showPage.shouldShowAssessmentReopenedBanner()
 }
 
 const withdrawApplication = async (page: Page) => {

--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -111,13 +111,13 @@ export const provideRequirements = async (page: Page) => {
   await requirementsPage.clickSubmit()
 }
 
-export const makeDecision = async (page: Page, acceptApplication = true) => {
+export const makeDecision = async (page: Page, options: { acceptApplication: boolean }) => {
   const tasklistPage = new TasklistPage(page)
   await tasklistPage.clickTask('Make a decision')
 
   const decisionPage = await AssessPage.initialize(page, 'Make a decision')
 
-  const decision = acceptApplication ? 'Accept' : 'Accommodation need only'
+  const decision = options.acceptApplication ? 'Accept' : 'Accommodation need only'
   await decisionPage.checkRadio(decision)
   await decisionPage.clickSubmit()
 }
@@ -172,8 +172,7 @@ export const shouldSeeAssessmentConfirmationScreen = async (page: Page) => {
 export const assessApplication = async (
   { page, user, person },
   applicationId: string,
-  emergencyApplication: boolean,
-  acceptApplication = true,
+  { emergencyApplication = false, acceptApplication = true } = {},
 ) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
@@ -197,9 +196,9 @@ export const assessApplication = async (
   await provideRequirements(page)
 
   // And I make a decision
-  await makeDecision(page, acceptApplication)
+  await makeDecision(page, { acceptApplication })
 
-  // And I provide matching information
+  // And I provide matching information if application is accepted
   if (acceptApplication) {
     await addMatchingInformation(page)
   }

--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -111,12 +111,14 @@ export const provideRequirements = async (page: Page) => {
   await requirementsPage.clickSubmit()
 }
 
-export const makeDecision = async (page: Page) => {
+export const makeDecision = async (page: Page, acceptApplication = true) => {
   const tasklistPage = new TasklistPage(page)
   await tasklistPage.clickTask('Make a decision')
 
   const decisionPage = await AssessPage.initialize(page, 'Make a decision')
-  await decisionPage.checkRadio('Accept')
+
+  const decision = acceptApplication ? 'Accept' : 'Accommodation need only'
+  await decisionPage.checkRadio(decision)
   await decisionPage.clickSubmit()
 }
 
@@ -171,6 +173,7 @@ export const assessApplication = async (
   { page, user, person },
   applicationId: string,
   emergencyApplication: boolean,
+  acceptApplication = true,
 ) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
@@ -194,10 +197,12 @@ export const assessApplication = async (
   await provideRequirements(page)
 
   // And I make a decision
-  await makeDecision(page)
+  await makeDecision(page, acceptApplication)
 
   // And I provide matching information
-  await addMatchingInformation(page)
+  if (acceptApplication) {
+    await addMatchingInformation(page)
+  }
 
   // And I check my answers
   await checkAssessAnswers(page)

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -8,7 +8,7 @@ import {
   withdrawAnApplicationAfterSubmission,
   withdrawAnApplicationBeforeSubmission,
 } from '../steps/apply'
-import { assessApplication, assessApplicationAsRejected, requestAndAddAdditionalInformation } from '../steps/assess'
+import { assessApplication, requestAndAddAdditionalInformation } from '../steps/assess'
 // import { matchAndBookApplication } from '../steps/match'
 
 // import { reviewAndApprovePlacementApplication, startAndCreatePlacementApplication } from '../steps/placementApplication'
@@ -26,7 +26,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
 }) => {
   await setRoles(page, [])
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false, true)
-  await assessApplication({ page, user, person }, id, false)
+  await assessApplication({ page, user, person }, id)
   await withdrawAnApplicationAfterSubmission(page, id)
   // Skip match until it's back
   // await matchAndBookApplication({ page, user, person }, id)
@@ -42,7 +42,7 @@ test('Apply, assess, match and book an emergency application for an Approved Pre
   await setRoles(page, ['Emergency APs'])
 
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, true)
-  await assessApplication({ page, user, person }, id, true)
+  await assessApplication({ page, user, person }, id, { emergencyApplication: true })
   // Skip match until it's back
   // await matchAndBookApplication({ page, user, person }, id)
 })
@@ -57,7 +57,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
   await setRoles(page, [])
 
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, false, false)
-  await assessApplication({ page, user, person }, id, false)
+  await assessApplication({ page, user, person }, id)
   await startAndCreatePlacementApplication({ page }, id)
   await withdrawPlacementApplication(page, id)
 
@@ -103,6 +103,6 @@ test('Record an appeal against a rejected application', async ({
 }) => {
   await setRoles(page, [])
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false, true)
-  await assessApplication({ page, user, person }, id, false, false)
+  await assessApplication({ page, user, person }, id, { acceptApplication: false })
   await recordAnAppealOnApplication(page, id)
 })

--- a/tests/apply.spec.ts
+++ b/tests/apply.spec.ts
@@ -2,12 +2,13 @@ import { test } from '../test'
 import {
   createApplication,
   enterAndConfirmCrn,
+  recordAnAppealOnApplication,
   startAnApplication,
   visitDashboard,
   withdrawAnApplicationAfterSubmission,
   withdrawAnApplicationBeforeSubmission,
 } from '../steps/apply'
-import { assessApplication, requestAndAddAdditionalInformation } from '../steps/assess'
+import { assessApplication, assessApplicationAsRejected, requestAndAddAdditionalInformation } from '../steps/assess'
 // import { matchAndBookApplication } from '../steps/match'
 
 // import { reviewAndApprovePlacementApplication, startAndCreatePlacementApplication } from '../steps/placementApplication'
@@ -91,4 +92,17 @@ test('Request further information on an Application, adds it and proceeds with t
 
   const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false)
   await requestAndAddAdditionalInformation({ page, user, person }, id)
+})
+
+test('Record an appeal against a rejected application', async ({
+  page,
+  user,
+  person,
+  indexOffenceRequired,
+  oasysSections,
+}) => {
+  await setRoles(page, [])
+  const id = await createApplication({ page, person, indexOffenceRequired, oasysSections }, true, false, true)
+  await assessApplication({ page, user, person }, id, false, false)
+  await recordAnAppealOnApplication(page, id)
 })


### PR DESCRIPTION
This tests that an appeal can be recorded against a rejected decision if a user has the role 'Appeals manager' - related to [(APS-240) Record appeal decision](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1466)

This could likely be extended to include viewing an an appeal once that piece of work is complete.

Have updated `assessApplication`workflow - it now takes a decision argument (e.g. accepted or rejected), and just checks for a success banner, not the exact text of the decision.