### PR TITLE
Handle pagination for assessments

### DIFF
--- a/pages/assess/listPage.ts
+++ b/pages/assess/listPage.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import { BasePage } from '../basePage'
 
 export class ListPage extends BasePage {
@@ -6,11 +7,24 @@ export class ListPage extends BasePage {
   }
 
   async clickAssessmentWithApplicationId(applicationId: string) {
-    await this.page
+    const assessmentRow = this.page
       .getByRole('row')
       .filter({ has: this.page.locator(`[data-cy-applicationid="${applicationId}"]`) })
       .first()
       .getByRole('link')
-      .click()
+    const nextLink = this.page.getByRole('link', { name: 'Next' })
+
+    try {
+      await expect(assessmentRow).toBeVisible()
+      await assessmentRow.click()
+    } catch (err) {
+      try {
+        await expect(nextLink).toBeVisible()
+      } catch {
+        throw err
+      }
+      await nextLink.click()
+      await this.clickAssessmentWithApplicationId(applicationId)
+    }
   }
 }


### PR DESCRIPTION
If there is more than one page of assessments, we need to handle this. We use the same technique we've used for tasks here. It's not the most DRY solution, but I think making is adaptable to different scenarios will be too much of a time sink.