### PR TITLE
Feature flag sufficient information confirmation screen

### DIFF
--- a/steps/assess.ts
+++ b/steps/assess.ts
@@ -46,9 +46,12 @@ export const confirmInsufficientInformation = async (page: Page) => {
   await additionalInformationPage.fillField('What additional information is needed?', 'This is a test')
   await additionalInformationPage.clickSubmit()
 
-  const confirmPage = await AssessPage.initialize(page, 'Suitability Assessment')
-  await confirmPage.checkRadio('Yes')
-  await confirmPage.clickSubmit()
+  const showConfirmationScreen = false
+  if (showConfirmationScreen) {
+    const confirmPage = await AssessPage.initialize(page, 'Suitability Assessment')
+    await confirmPage.checkRadio('Yes')
+    await confirmPage.clickSubmit()
+  }
 }
 
 export const addAdditionalInformation = async (page: Page) => {


### PR DESCRIPTION
We have a feature flag that determines whether to show this confirmation screen or not.
It would be good to read the values from the feature flag service but given we will move these tests into the UI repo soon enough it feels like a waste of time at the moment